### PR TITLE
Fix: added SegWit parsing in DecodeBlock/DecodeTx (occurs in AuxPoW)

### DIFF
--- a/block.go
+++ b/block.go
@@ -1,10 +1,16 @@
 package doge
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"log"
+)
 
 const (
 	VersionAuxPoW = 256
 	CoinbaseVOut  = 0xffffffff
+	MaxScriptSize = 10_000     // MAX_SCRIPT_SIZE from Dogecoin Core (script.h)
+	MaxVarIntSize = 0x02000000 // MAX_SIZE from Dogecoin Core (serialize.h)
 )
 
 type HashID []byte
@@ -61,6 +67,7 @@ type BlockTxIn struct {
 	VOut     uint32
 	Script   []byte // varied length
 	Sequence uint32
+	Witness  [][]byte // varied length, for SegWit transactions
 }
 
 type BlockTxOut struct {
@@ -68,22 +75,52 @@ type BlockTxOut struct {
 	Script []byte // varied length
 }
 
-// DecodeBlock decodes a block from a byte slice.
+// DecodeBlock decodes a block from a byte slice (original API)
 // If calcHash is true, the block hash is calculated and stored in the Block.BlockID field.
 // Returns false if the serialized block data is malformed.
 func DecodeBlock(blockBytes []byte, calcHash bool) (Block, bool) {
-	s := NewStream(blockBytes)
-	return readBlock(s, calcHash), s.Complete()
+	b, err := DecodeBlockErr(blockBytes, calcHash)
+	return b, err == nil
 }
 
-func readBlock(s *Stream, calcHash bool) (b Block) {
+// DecodeBlockErr decodes a block from a byte slice (enhanced API)
+// If calcHash is true, the block hash is calculated and stored in the Block.BlockID field.
+// Returns an error if the serialized block data is malformed.
+func DecodeBlockErr(blockBytes []byte, calcHash bool) (Block, error) {
+	s := NewStream(blockBytes)
+	b, err := readBlock(s, calcHash)
+	if err == nil && !s.Complete() {
+		if !s.Valid() {
+			err = fmt.Errorf("invalid block: truncated / incomplete block (at %v of %v)", s.pos, s.len)
+		} else {
+			err = fmt.Errorf("invalid block: unexpected data at end of block (at %v of %v)", s.pos, s.len)
+		}
+	}
+	return b, err
+}
+
+func readBlock(s *Stream, calcHash bool) (b Block, err error) {
 	b.Header = readHeader(s, calcHash)
+	if !s.Valid() {
+		return b, fmt.Errorf("invalid block: unexpected end of block in header (at %v of %v)", s.pos, s.len)
+	}
 	if b.Header.IsAuxPoW() {
-		b.AuxPoW = readMerkleTx(s, calcHash)
+		mtx, err := readMerkleTx(s, calcHash)
+		if err != nil {
+			return b, fmt.Errorf("invalid block: %v", err)
+		}
+		b.AuxPoW = mtx
 	}
 	numTx := s.VarUint()
 	for i := uint64(0); i < numTx; i++ {
-		b.Tx = append(b.Tx, readTx(s, calcHash))
+		tx, err := readTx(s, calcHash)
+		if err != nil {
+			return b, fmt.Errorf("invalid block: bad tx %v of %v: %v", i, numTx, err)
+		}
+		if !s.Valid() {
+			return b, fmt.Errorf("invalid block: unexpected end of block in tx %v of %v: %v", i, numTx, err)
+		}
+		b.Tx = append(b.Tx, tx)
 	}
 	return
 }
@@ -103,14 +140,18 @@ func readHeader(s *Stream, calcHash bool) (b BlockHeader) {
 	return
 }
 
-func readMerkleTx(s *Stream, calcHash bool) *MerkleTx {
+func readMerkleTx(s *Stream, calcHash bool) (*MerkleTx, error) {
 	var m MerkleTx
-	m.CoinbaseTx = readTx(s, calcHash)
+	tx, err := readTx(s, calcHash)
+	if err != nil {
+		return nil, fmt.Errorf("invalid merkle tx: %v", err)
+	}
+	m.CoinbaseTx = tx
 	m.ParentHash = s.Bytes(32)
 	m.CoinbaseBranch = readMerkleBranch(s)
 	m.BlockchainBranch = readMerkleBranch(s)
 	m.ParentBlock = readHeader(s, calcHash)
-	return &m
+	return &m, nil
 }
 
 func readMerkleBranch(s *Stream) (b MerkleBranch) {
@@ -122,47 +163,156 @@ func readMerkleBranch(s *Stream) (b MerkleBranch) {
 	return
 }
 
-// DecodeTx decodes a transaction from a byte slice.
+// DecodeTx decodes a transaction from a byte slice (original API)
 // If calcHash is true, the transaction hash is calculated and stored in the BlockTx.TxID field.
-// Returns false if the serialized transaction data is malformed.
-func DecodeTx(txBytes []byte, calcHash bool) (BlockTx, bool) {
-	s := NewStream(txBytes)
-	return readTx(s, calcHash), s.Complete()
+// Returns false if the serialized tx data is malformed.
+func DecodeTx(txBytes []byte, txid string) (BlockTx, bool) {
+	tx, err := DecodeTxErr(txBytes, true)
+	return tx, err == nil
 }
 
-func readTx(s *Stream, calcHash bool) (tx BlockTx) {
-	start := s.pos
+// DecodeTxErr decodes a transaction from a byte slice (enhanced API)
+// If calcHash is true, the transaction hash is calculated and stored in the BlockTx.TxID field.
+// Returns an error if the serialized transaction data is malformed.
+func DecodeTxErr(txBytes []byte, calcHash bool) (BlockTx, error) {
+	s := NewStream(txBytes)
+	tx, err := readTx(s, calcHash)
+	if err == nil && !s.Complete() {
+		if !s.Valid() {
+			err = fmt.Errorf("invalid transaction: truncated / incomplete transaction (at %v of %v)", s.pos, s.len)
+		} else {
+			err = fmt.Errorf("invalid transaction: unexpected data at end of transaction (at %v of %v)", s.pos, s.len)
+		}
+	}
+	return tx, err
+}
+
+func readTx(s *Stream, calcHash bool) (tx BlockTx, err error) {
+	markerFound := false
+	skippedVinVout := false
+	flags := uint8(0)
+	startOfTx := s.pos
 	tx.Version = s.Uint32le()
-	num_tx_in := s.VarUint()
-	for i := uint64(0); i < num_tx_in; i++ {
-		tx.VIn = append(tx.VIn, readTxIn(s))
+	beforeWitnessFlag := s.pos
+	afterWitnessFlag := s.pos
+	// Detect extended transaction serialization format: "The marker MUST be a 1-byte zero value: 0x00"
+	// However, Core uses ReadCompactSize via `s >> tx.vin` in UnserializeTransaction, so anything goes.
+	// The following nested if-else structure exactly mirrors Core.
+	tx_in := s.VarUint()
+	if tx_in == 0 {
+		// "The flag MUST be a 1-byte non-zero value. Currently, 0x01 MUST be used."
+		// However, Core checks for != 0, so we do too (bug?).
+		markerFound = true
+		flags = s.Bytes(1)[0]
+		afterWitnessFlag = s.pos
+		if flags != 0 {
+			// Here Core parses full VIn and VOut vectors.
+			tx_in = s.VarUint()
+			tx.VIn, tx.VOut, err = readVinVout(s, tx_in)
+			if err != nil {
+				return tx, err
+			}
+		} else {
+			// VIn/VOut parsing is skipped entirely if flags is zero! (as per Core)
+			// This may be an oversight in Core - probably an exploit.
+			skippedVinVout = true
+		}
+	} else {
+		// We read a non-empty vin. Assume a normal vin/vout follows (as per Core)
+		tx.VIn, tx.VOut, err = readVinVout(s, tx_in)
+		if err != nil {
+			return tx, err
+		}
 	}
-	num_tx_out := s.VarUint()
-	for i := uint64(0); i < num_tx_out; i++ {
-		tx.VOut = append(tx.VOut, readTxOut(s))
+	// Here Core tests if the low bit is set.
+	beforeWitnessData := s.pos
+	if (flags & 1) != 0 {
+		// The witness flag is present: read witness data.
+		// Core parses `std::vector<std::vector<unsigned char>>` per vin.
+		flags ^= 1 // Core toggles the low bit.
+		for i := uint64(0); i < tx_in; i++ {
+			numStackItems := s.VarUint()
+			for k := uint64(0); k < numStackItems; k++ {
+				itemLen := s.VarUint()
+				if itemLen > MaxVarIntSize {
+					return tx, fmt.Errorf("invalid transaction: witness data too large: %v for vin %v stack item %v", itemLen, i, k)
+				}
+				itemData := s.Bytes(itemLen)
+				tx.VIn[i].Witness = append(tx.VIn[i].Witness, itemData)
+			}
+		}
 	}
+	// Here Core treats non-zero flags as an error.
+	if flags != 0 {
+		return tx, fmt.Errorf("invalid transaction: unknown transaction optional data: %v", flags)
+	}
+	afterWitnessData := s.pos
 	tx.LockTime = s.Uint32le()
 	// Compute TX hash from transaction bytes.
 	if calcHash && s.Valid() {
-		tx.TxID = DoubleSha256(s.buf[start:s.pos])
+		endOfTx := s.pos
+		if markerFound {
+			// Extended serialization: txid = hash(version | (no marker+flag) | vin/vout | (no witness) | locktime)
+			lenSeg1 := beforeWitnessFlag - startOfTx
+			lenSeg2 := beforeWitnessData - afterWitnessFlag
+			lenSeg3 := endOfTx - afterWitnessData
+			total := int(lenSeg1 + lenSeg2 + lenSeg3)
+			buf := make([]byte, total)
+			copy(buf, s.buf[startOfTx:beforeWitnessFlag])
+			copy(buf[lenSeg1:], s.buf[afterWitnessFlag:beforeWitnessData])
+			copy(buf[lenSeg1+lenSeg2:], s.buf[afterWitnessData:endOfTx])
+			tx.TxID = DoubleSha256(buf)
+		} else {
+			// No witness marker: txid is the hash of the entire transaction
+			tx.TxID = DoubleSha256(s.buf[int(startOfTx):int(endOfTx)])
+		}
+		if skippedVinVout {
+			// Core skips VIn/Vout parsing entirely if flags is zero (bug?)
+			log.Printf("[!] WARNING: skipped VIn/Vout parsing entirely, as per Core implementation (bug?): %v", TxHashToHex(tx.TxID))
+		}
+	}
+	return tx, nil
+}
+
+func readVinVout(s *Stream, tx_in uint64) (VIn []BlockTxIn, VOut []BlockTxOut, err error) {
+	for i := uint64(0); i < tx_in; i++ {
+		vin, err := readTxIn(s)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error reading tx input %d: %v", i, err)
+		}
+		VIn = append(VIn, vin)
+	}
+	tx_out := s.VarUint()
+	for i := uint64(0); i < tx_out; i++ {
+		vout, err := readTxOut(s)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error reading tx output %d: %v", i, err)
+		}
+		VOut = append(VOut, vout)
 	}
 	return
 }
 
-func readTxIn(s *Stream) (in BlockTxIn) {
+func readTxIn(s *Stream) (in BlockTxIn, err error) {
 	in.TxID = s.Bytes(32)
 	in.VOut = s.Uint32le()
-	script_len := s.VarUint()
-	in.Script = s.Bytes(script_len)
+	scriptLen := s.VarUint()
+	if scriptLen > MaxScriptSize {
+		return in, fmt.Errorf("script length %d exceeds maximum allowed size of %d", scriptLen, MaxScriptSize)
+	}
+	in.Script = s.Bytes(uint64(scriptLen))
 	in.Sequence = s.Uint32le()
-	return
+	return in, nil
 }
 
-func readTxOut(s *Stream) (out BlockTxOut) {
+func readTxOut(s *Stream) (out BlockTxOut, err error) {
 	out.Value = int64(s.Uint64le())
-	script_len := s.VarUint()
-	out.Script = s.Bytes(script_len)
-	return
+	scriptLen := s.VarUint()
+	if scriptLen > MaxScriptSize {
+		return out, fmt.Errorf("script length %d exceeds maximum allowed size of %d", scriptLen, MaxScriptSize)
+	}
+	out.Script = s.Bytes(uint64(scriptLen))
+	return out, nil
 }
 
 // EncodeTx encodes a transaction to a byte slice.

--- a/block_test.go
+++ b/block_test.go
@@ -30,9 +30,9 @@ func TestBlock(t *testing.T) {
 		1000000000,
 		1045842885,
 	}
-	b, ok := DecodeBlock(hx2b(hex), true)
-	if !ok {
-		t.Errorf("TestBlock: failed to decode block")
+	b, err := DecodeBlockErr(hx2b(hex), true)
+	if err != nil {
+		t.Errorf("TestBlock: failed to decode block: %v", err)
 	}
 	// log.Printf("Block: ver %x prev %v merkel %v ntx %v", b.Header.Version, revhex(b.Header.PrevBlock), revhex(b.Header.MerkleRoot), len(b.Tx))
 	if len(b.Tx) != expectTxs {
@@ -70,9 +70,9 @@ func TestEncodeTx(t *testing.T) {
 	if err != nil {
 		t.Errorf("TestEncodeTx: failed to encode transaction: %v", err)
 	}
-	tx2, ok := DecodeTx(txBytes, false)
-	if !ok {
-		t.Errorf("TestEncodeTx: failed to decode transaction (round trip failed)")
+	tx2, err := DecodeTxErr(txBytes, false)
+	if err != nil {
+		t.Errorf("TestEncodeTx: failed to decode transaction (round trip failed): %v", err)
 	}
 	if tx2.Version != tx.Version {
 		t.Errorf("TestEncodeTx: wrong version: %v vs %v", tx2.Version, tx.Version)
@@ -104,5 +104,20 @@ func TestEncodeTx(t *testing.T) {
 		if tx2.VOut[i].Value != vout.Value {
 			t.Errorf("TestEncodeTx: wrong output: %v vs %v", tx2.VOut[i].Value, vout.Value)
 		}
+	}
+}
+
+const (
+	segWitTxHex  = "01000000000101438afdb24e414d54cc4a17a95f3d40be90d23dfeeb07a48e9e782178efddd8890100000000fdffffff020db9a60000000000160014b549d227c9edd758288112fe3573c1f85240166880a81201000000001976a914ae28f233464e6da03c052155119a413d13f3380188ac024730440220200254b765f25126334b8de16ee4badf57315c047243942340c16cffd9b11196022074a9476633f093f229456ad904a9d97e26c271fc4f01d0501dec008e4aae71c2012102c37a3c5b21a5991d3d7b1e203be195be07104a1a19e5c2ed82329a56b431213000000000"
+	segWitTxHash = "c06aaaa2753dc4e74dd4fe817522dc3c126fd71792dd9acfefdaff11f8ff954d"
+)
+
+func TestSegWitTx(t *testing.T) {
+	tx, err := DecodeTxErr(hx2b(segWitTxHex), true)
+	if err != nil {
+		t.Errorf("TestSegWitTx: failed to decode transaction: %v", err)
+	}
+	if tx.TxID.ToHex() != segWitTxHash {
+		t.Errorf("TestSegWitTx: wrong transaction hash: %v vs %v", tx.TxID.ToHex(), segWitTxHash)
 	}
 }


### PR DESCRIPTION
The new approach exactly mirrors the parsing logic in Core to avoid inconsistent parsing outcomes.

Now also detects invalid script size and varInt size as per Core, which typically happen when parsing goes astray.

Also added DecodeBlockErr/DecodeTxErr that return error details for debugging issues like this.