### PR TITLE
fix(bip32): EncodePrivateWIF for classic WIF (#2)

### DIFF
--- a/bip32.go
+++ b/bip32.go
@@ -51,9 +51,23 @@ func (key *Bip32Key) ChildNumber() uint32 {
 	return key.child_number
 }
 
-// EncodeWIF encodes this key in Bip32 WIF format (dgpv,dgub)
+// EncodeWIF encodes this key in BIP32 extended-key serialization (dgpv/dgub).
+//
+// Historical name: this is NOT classic Wallet Import Format (the single private
+// key "WIF" used by dumpprivkey / importprivkey). For classic WIF of the EC
+// private key, use EncodePrivateWIF. See https://github.com/dogeorg/doge/issues/2
 func (key *Bip32Key) EncodeWIF() string {
 	return EncodeBip32WIF(key)
+}
+
+// EncodePrivateWIF returns classic Wallet Import Format (compressed pubkey
+// marker) for a private Bip32Key. Returns an error if this key is public-only.
+func (key *Bip32Key) EncodePrivateWIF() (string, error) {
+	pk, err := key.GetECPrivKey()
+	if err != nil {
+		return "", err
+	}
+	return EncodeECPrivKeyWIF(pk, key.chain), nil
 }
 
 // Public returns the Public Bip32Key corresponding to a Private Bip32Key.

--- a/bip32_test.go
+++ b/bip32_test.go
@@ -1,6 +1,7 @@
 package doge
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 )
@@ -418,5 +419,44 @@ func TestBip32InvalidKeys(t *testing.T) {
 			t.Error(fmt.Errorf("XPrv %v should not decode: %v", it, XPrv))
 		}
 		//log.Printf("%v", err)
+	}
+}
+
+func TestBip32EncodePrivateWIF(t *testing.T) {
+	// EncodePrivateWIF must return classic WIF, not BIP32 extended (dgpv/dgub).
+	// Seed from BIP32 test vector 1.
+	master, err := Bip32MasterFromSeed(hx2b("000102030405060708090a0b0c0d0e0f"), &BitcoinMainChain)
+	if err != nil {
+		t.Fatalf("Bip32MasterFromSeed: %v", err)
+	}
+	classic, err := master.EncodePrivateWIF()
+	if err != nil {
+		t.Fatalf("EncodePrivateWIF: %v", err)
+	}
+	extended := master.EncodeWIF()
+	if classic == extended {
+		t.Fatalf("EncodePrivateWIF returned extended key: %s", classic)
+	}
+	// Classic WIF starts with K/L (compressed mainnet) or 5 (uncompressed); BIP32 xprv with xprv/dgpv
+	if len(classic) < 50 {
+		t.Fatalf("EncodePrivateWIF too short: %s", classic)
+	}
+	pk, chain, err := DecodeECPrivKeyWIF(classic, nil)
+	if err != nil {
+		t.Fatalf("DecodeECPrivKeyWIF failed for EncodePrivateWIF output: %v (%s)", err, classic)
+	}
+	if chain != &BitcoinMainChain {
+		t.Fatalf("wrong chain from decoded WIF")
+	}
+	want, err := master.GetECPrivKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(pk[:], want[:]) {
+		t.Fatalf("decoded key mismatch")
+	}
+	// Public key cannot produce classic private WIF
+	if _, err := master.Public().EncodePrivateWIF(); err == nil {
+		t.Fatalf("expected error encoding private WIF from public key")
 	}
 }


### PR DESCRIPTION
## #2 — \`Bip32Key.EncodeWIF\` returns extended keys

\`EncodeWIF\` has always returned **BIP32 extended** serialization (\`dgpv\`/\`dgub\`), not classic Wallet Import Format. Renaming would break every caller/test that round-trips xprv/xpub via \`EncodeWIF\`.

### Fix (compat-preserving)
- Document \`EncodeWIF\` as BIP32 extended (historical name)
- Add \`EncodePrivateWIF() (string, error)\` → classic compressed WIF via \`EncodeECPrivKeyWIF\`
- Test: classic WIF ≠ extended; round-trips through \`DecodeECPrivKeyWIF\`; public key errors

If maintainers prefer a breaking rename (\`EncodeWIF\` → classic, \`EncodeExtended\` for BIP32), happy to follow up.

## DOGE
Tips/contract: \`DTRJECKXfxgnSzGbt7TYRikLPDocqvdmo5\` · trefongwork@gmail.com